### PR TITLE
Rails 6 Upgrade Part X: `template` & `sources` not `template.source`

### DIFF
--- a/lib/action_view/template/handlers/rjs.rb
+++ b/lib/action_view/template/handlers/rjs.rb
@@ -5,8 +5,8 @@ module ActionView
       class_attribute :default_format
       self.default_format = :js
 
-      def call(template)
-        "update_page do |page|;#{template.source}\nend"
+      def call(template, source)
+        "update_page do |page|;#{source}\nend"
       end
     end
   end

--- a/prototype-rails.gemspec
+++ b/prototype-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = 'prototype-rails'
-  spec.version  = '4.1.4'
+  spec.version  = '4.2.0'
   spec.summary  = 'Prototype, Scriptaculous, and RJS for Ruby on Rails'
   spec.homepage = 'http://github.com/rails/prototype-rails'
   spec.author   = 'Xavier Noria'


### PR DESCRIPTION
## The Story So Far

We have been trying to upgrade `sbn` to Rails 6. On the last attempt, we were [seeing a template error](https://sentry.io/organizations/voxmedia/issues/2394590564/?project=9136&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox&statsPeriod=14d). Here it is:

### SENTRY ERROR
```
ActionView::Template::Error

undefined method `_app_unison_cells_unison_entry_post_head_html_erb__1347066537634862207_26377380' for #<#<Class:0x00000000046d3338>:0x00000000046fa5a0>
Did you mean?  _app_unison_cells_unison_entry_page_display_html_erb___2077844904212712566_37183300

NoMethodError

undefined method `_app_unison_cells_unison_entry_post_head_html_erb__1347066537634862207_26377380' for #<#<Class:0x00000000046d3338>:0x00000000046fa5a0>
Did you mean?  _app_unison_cells_unison_entry_page_display_html_erb___2077844904212712566_37183300
```

I haven't been able to find anything the specifically references this problem when upgrading to Rails 6, but there is a deprecation warning about `ActionView::Template` when starting up `sbn` on the [`rails-6` branch](https://github.com/voxmedia/sbn/tree/rails-6). No definitive answers, but close. Here's the 

### DEPRECATION WARNING
```
🤔 docker attach sbn_app_1
warning Your current version of Yarn is out of date. The latest version is "1.22.5", while you're on "1.22.4".
=> Booting Unicorn
=> Rails 6.0.3.7 application starting in development http://0.0.0.0:3000
=> Run `rails server --help` for more startup options
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> #<ActionView::Template::Handlers::RJS:0x00000000085619d8>.call(template)
To:
  >> #<ActionView::Template::Handlers::RJS:0x00000000085619d8>.call(template, source)
```

## Purpose

So, I'm trying to resolve the DEPRECATION WARNING with this PR.

I got here by [reading a github issue](https://github.com/haml/haml/issues/1007) and looked at [the related pull request](https://github.com/haml/haml/pull/1008). I've link to those here, but it was mostly find the place to make the change suggested. It was all in the DEPRECATION WARNING message, but I had to decipher / read it.

## Changes
- update the signature of the `prototype-rails/lib/action_view/template/handlers/rjs.rb` that maps to `ActionView::Template::Handlers::RJS.call` to `call(template, source)`.
- update the body to use `source` instead of `template.source` - this seems like a reasonable thing to do.

## Strangeness
- I noticed that this Gemfile.lock has been [pegged at Rails `6.1.1`](https://github.com/voxmedia/prototype-rails/blob/eb-rails-6-upgrade/Gemfile.lock#L96), which is higher than `sbn` which is at `6.0.3.7`.

# OUTCOME
Merging this, which will roll the version of the gem to 4.2.0, will update sbn gemfile to use new version.