### PR TITLE
This version is not rails 6 compatible

### DIFF
--- a/prototype-rails.gemspec
+++ b/prototype-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = 'prototype-rails'
-  spec.version  = '4.1.4'
+  spec.version  = '4.1.5'
   spec.summary  = 'Prototype, Scriptaculous, and RJS for Ruby on Rails'
   spec.homepage = 'http://github.com/rails/prototype-rails'
   spec.author   = 'Xavier Noria'
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
 
   spec.files = %w(README.md Rakefile Gemfile MIT-LICENSE) + Dir['lib/**/*', 'vendor/**/*']
 
-  spec.add_dependency('rails', '>= 4.2')
+  spec.add_dependency('rails', '>= 4.2', '< 6.0')
   spec.add_development_dependency('mocha')
   spec.add_development_dependency('rails-controller-testing')
   spec.license = "MIT"


### PR DESCRIPTION
This updates v4.1.4 to v4.1.5 by correcting its gemspec to note that this version is not compatible with Rails 5.

By then updating sbn to v4.1.5, we ensure we don't/can't deploy a rails 6 branch without also updating this incompatible version.

After approval, this PR should be merged into the new `4-1-stable` branch, the result tagged `v4.1.5`, and not merged into master. The current sbn should then have this gem updated to `4.1.5`. The `v4.1.4` tag should then be deleted because it incorrectly claims it is rails 6 compatible when it is not.