### PR TITLE
Compatibility with both rails 5 and 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   rails-controller-testing
 
 BUNDLED WITH
-   2.2.3
+   2.3.6

--- a/lib/action_view/template/handlers/rjs.rb
+++ b/lib/action_view/template/handlers/rjs.rb
@@ -5,8 +5,9 @@ module ActionView
       class_attribute :default_format
       self.default_format = :js
 
-      def call(template, source)
-        "update_page do |page|;#{source}\nend"
+      def call(template, source=nil)
+        block_source = Rails.version >= "6" ? source : template.source
+        "update_page do |page|;#{block_source}\nend"
       end
     end
   end

--- a/prototype-rails.gemspec
+++ b/prototype-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = 'prototype-rails'
-  spec.version  = '4.2.0'
+  spec.version  = '4.2.1'
   spec.summary  = 'Prototype, Scriptaculous, and RJS for Ruby on Rails'
   spec.homepage = 'http://github.com/rails/prototype-rails'
   spec.author   = 'Xavier Noria'

--- a/prototype-rails.gemspec
+++ b/prototype-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = 'prototype-rails'
-  spec.version  = '4.1.4'
+  spec.version  = '4.1.5'
   spec.summary  = 'Prototype, Scriptaculous, and RJS for Ruby on Rails'
   spec.homepage = 'http://github.com/rails/prototype-rails'
   spec.author   = 'Xavier Noria'
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
 
   spec.files = %w(README.md Rakefile Gemfile MIT-LICENSE) + Dir['lib/**/*', 'vendor/**/*']
 
-  spec.add_dependency('rails', '>= 4.2')
+  spec.add_dependency('rails', '>= 4.2', '< 6.0')
   spec.add_development_dependency('mocha')
   spec.add_development_dependency('rails-controller-testing')
   spec.license = "MIT"

--- a/prototype-rails.gemspec
+++ b/prototype-rails.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
 
   spec.files = %w(README.md Rakefile Gemfile MIT-LICENSE) + Dir['lib/**/*', 'vendor/**/*']
 
-  spec.add_dependency('rails', '>= 4.2', '< 6.0')
+  spec.add_dependency('rails', '>= 4.2')
   spec.add_development_dependency('mocha')
   spec.add_development_dependency('rails-controller-testing')
   spec.license = "MIT"


### PR DESCRIPTION
See first #3.

This PR updates `#call` to work under either rails 5 or 6. See #2 for why rails 6 needs the new argument.

I did this by explicitly testing `Rails.version` just because we know that is what makes one work and one not. Other opinions are valid, e.g. [`HAML::Plugin`](https://github.com/haml/haml/pull/1008/files#diff-fa62b635d91e44dc3a99c0e4ba6e1b0362b51a263406d797d3b290daf4a3ecccR23) fixed it by testing for `source.nil?`. I care 2/10.

After approval, this PR should be merged into `master`, and the result tagged `v4.2.1`.

We should then delete the `v4.2.0` tag, which incorrectly claims it is rails 5 compatible which it is not.

sbn's rails 6 branches should then be updated to bump this gem's version from `4.1.5` to `4.2.1`.